### PR TITLE
Handle promise rejections

### DIFF
--- a/src/endpoints/compare.js
+++ b/src/endpoints/compare.js
@@ -30,8 +30,17 @@ var compareEndpoint = (async (req, res) => {
 		imageBlocal = tempy.file(),
 		compareImage = tempy.file();
 
-	await asyncDownload(imageA, imageAlocal);
-	await asyncDownload(imageB, imageBlocal);
+	var errored = false;
+	await asyncDownload(imageA, imageAlocal).catch(() => {
+		errored = true;
+	});
+	await asyncDownload(imageB, imageBlocal).catch(() => {
+		errored = true;
+	});;
+	if ( errored ) {
+		errorResponse(res, 400, 'Error downloading images');
+		return;
+	}
 
 	var unlinkImages = () => {
 		fs.unlink(imageAlocal,()=>{});


### PR DESCRIPTION
```
(node:38960) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Not Found
```